### PR TITLE
New rule engine

### DIFF
--- a/src/dotty/tools/dotc/Compiler.scala
+++ b/src/dotty/tools/dotc/Compiler.scala
@@ -15,6 +15,7 @@ import transform.TreeTransforms.{TreeTransform, TreeTransformer}
 import core.DenotTransformers.DenotTransformer
 import core.Denotations.SingleDenotation
 import dotty.tools.backend.jvm.{GenBCode, LabelDefs}
+import dotty.tools.dotc.transform.autocollections.{AutoCollections, PreAutoCollections}
 import dotty.tools.dotc.transform.linker.{AnalyzeClosures, MinimizeClosures, Rewrites}
 
 class Compiler {

--- a/src/dotty/tools/dotc/core/Phases.scala
+++ b/src/dotty/tools/dotc/core/Phases.scala
@@ -3,18 +3,20 @@ package core
 
 import Periods._
 import Contexts._
-import dotty.tools.backend.jvm.{LabelDefs, GenBCode}
+import dotty.tools.backend.jvm.{GenBCode, LabelDefs}
 import util.DotClass
 import DenotTransformers._
 import Denotations._
 import Decorators._
 import config.Printers._
-import scala.collection.mutable.{ListBuffer, ArrayBuffer}
-import dotty.tools.dotc.transform.TreeTransforms.{TreeTransformer, MiniPhase, TreeTransform}
+
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import dotty.tools.dotc.transform.TreeTransforms.{MiniPhase, TreeTransform, TreeTransformer}
 import dotty.tools.dotc.transform._
 import Periods._
 import typer.{FrontEnd, RefChecks}
 import ast.tpd
+import dotty.tools.dotc.transform.autocollections.PreAutoCollections
 
 trait Phases {
   self: Context =>

--- a/src/dotty/tools/dotc/transform/autocollections/AutoCollections.scala
+++ b/src/dotty/tools/dotc/transform/autocollections/AutoCollections.scala
@@ -1,62 +1,19 @@
 package dotty.tools.dotc.transform.autocollections
 
-import dotty.tools.dotc.ast.Trees._
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Decorators.{StringDecorator, sourcePos}
+import dotty.tools.dotc.core.Decorators.sourcePos
 import dotty.tools.dotc.core.Names.Name
-import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols.Symbol
-import dotty.tools.dotc.core.TypeErasure
 import dotty.tools.dotc.core.Types.Type
-import dotty.tools.dotc.transform.TreeTransforms.{MiniPhaseTransform, TransformerInfo}
 import dotty.tools.dotc.transform.BuildCallGraph
+import dotty.tools.dotc.transform.TreeTransforms.{MiniPhaseTransform, TransformerInfo}
+import dotty.tools.dotc.transform.autocollections.Rules._
 
 import scala.collection.{immutable, mutable}
 
 /** A transformation which substitutes an auto collection by an implementation
-  * following the following rules:
-  *
-  * Immutable
-  *
-  * - AutoSeq
-  *   - [[mutable.ListBuffer]] if `head` and `tail` are the only operations
-  *   - [[immutable.Queue]] if `:+` or `+:` are used
-  *   - [[mutable.WrappedArray]] if operations are by index accesses (e.g. `apply`),
-  *      unless elements are [[Char]] then use [[immutable.WrappedString]]
-  *   - [[immutable.Range]] if all elements are numbers with a constant delta
-  *   - [[immutable.Vector]] otherwise
-  *
-  * - AutoMap
-  *   - [[immutable.HashMap]] if elements are added
-  *   - If no element are added
-  *     - [[mutable.AnyRefMap]] if keys' type is subtype of [[AnyRef]]
-  *     - [[immutable.LongMap]] if keys' type is [[Long]]
-  *     - [[mutable.HashMap]] otherwise
-  *   // We can consider adding an option of creating a sortedMap
-  *   // in this case, if someone actually uses operations that reveal sorting
-  *   // we need to create a [[immutable.TreeMap]], otherwise follow the algorithm above
-  *
-  * - AutoSet
-  *   - [[immutable.HashSet]]
-  *
-  * Mutable
-  *
-  * - AutoSeq
-  *   - [[mutable.WrappedArray]] if operations are by index accesses (e.g. `apply`)
-  *   - otherwise:
-  *     - [[mutable.UnrolledBuffer]] if type is known
-  *     - [[mutable.ListBuffer]] otherwise
-  *
-  * - AutoMap
-  *   - [[mutable.HashMap]]
-  *
-  * - AutoSet
-  *   - [[mutable.HashSet]]
-  *
-  * Lazy
-  *   - Not yet supported
+  * following a set of rules
   */
 class AutoCollections extends MiniPhaseTransform {
 
@@ -65,179 +22,99 @@ class AutoCollections extends MiniPhaseTransform {
 
   override def phaseName: String = "autocollections"
 
+  /** Rules for `Seq`
+    *
+    * Immutable:
+    *   - [[immutable.Range]] if all elements are numbers with a constant delta
+    *   - [[immutable.List]] if `head`, `tail`, `prepend`, `nonEmpty`, `isEmpty`
+    *      are the only operations
+    *   - [[immutable.Queue]] if operations contains `append`
+    *   - [[mutable.WrappedArray]] if operations are by index accesses (e.g. `apply`),
+    *      unless elements are [[Char]] then use [[immutable.WrappedString]]
+    *   - [[immutable.Vector]] otherwise
+    *
+    * Mutable:
+    *   - [[mutable.WrappedArray]] if operations are by index accesses (e.g. `apply`)
+    *   - otherwise:
+    *     - [[mutable.UnrolledBuffer]] if type is known
+    *     - [[mutable.ListBuffer]] otherwise
+    */
+  val seqRules = List(
+    new Range,
+    new ListR,
+    new Queue,
+    new WrappedString,
+    new WrappedArray,
+    new Vector,
+    new UnrolledBuffer,
+    new ListBuffer
+  )
+
+  /** Rules for `Map`
+    *
+    * Immutable:
+    *   - [[immutable.HashMap]] if elements are added
+    *   - If no element are added
+    *     - [[mutable.AnyRefMap]] if keys' type is subtype of [[AnyRef]]
+    *     - [[mutable.LongMap]] if keys' type is [[Long]]
+    *     - [[mutable.HashMap]] otherwise
+    *   // We can consider adding an option of creating a sortedMap
+    *   // in this case, if someone actually uses operations that reveal sorting
+    *   // we need to create a [[immutable.TreeMap]], otherwise follow the algorithm above
+    *
+    *   Mutable:
+    *     - [[mutable.AnyRefMap]] if keys' type is subtype of [[AnyRef]]
+    *     - [[mutable.LongMap]] if keys' type is [[Long]]
+    */
+  val mapRules = List(
+    new HashMap,
+    new MutableAnyRefMap,
+    new MutableLongMap,
+    new MutableHashMap
+  )
+
+  /** Rules for `Set`
+    *
+    * Immutable:
+    *   - [[immutable.HashSet]]
+    *
+    * Mutable:
+    *   - [[mutable.HashSet]]
+    */
+  val setRules = List(
+    new HashSet,
+    new MutableHashSet
+  )
+
 
   override def transformBlock(tree: Block)(implicit ctx: Context, info: TransformerInfo): Tree = {
     val autoCollections = ctx.preAutoCollectionPhase.asInstanceOf[PreAutoCollections].instances
 
     autoCollections.get(tree).fold(tree: Tree) { collection =>
-      val impl = pickImplementation(collection)
 
       val methods: Set[Name] = methodCalls(collection.symbol)
         .filterNot(_.isConstructor)
         .map(_.name)
 
+
+      val impl = collection match {
+        case seq: AutoSeq => evaluate(seqRules, seq, methods)
+        case map: AutoMap => evaluate(mapRules, map, methods)
+        case set: AutoSet => evaluate(setRules, set, methods)
+      }
+
       println("-" * 60)
       println(s"Methods called: ${methods.mkString(", ")}")
-      println(impl.tpe.classSymbol)
+      println {
+        val sym = impl.fold("Not found")(_.tpe.classSymbol.toString)
+        s"Implementation: $sym"
+      }
       println("-" * 60)
 
-      if (impl.isEmpty) {
-        ctx.error("Lazy collections are not supported", tree.pos)
+      impl.getOrElse {
+        ctx.error("No rule satisfied for this use case", tree.pos)
         tree
       }
-      else impl
-    }
-  }
-
-  private def pickImplementation(collection: AutoCollection)(implicit ctx: Context): Tree = {
-
-    import Methods._
-
-    /** Default collection builder
-      *
-      * @return a tree of the form `module.apply[T](elems)`
-      */
-    def buildCollection(collection: AutoCollection)
-                       (module: Symbol,
-                        tpParams: List[Type] = collection.tpParams,
-                        args: List[Tree] = collection.elems) = {
-      ref(module)
-        .select(nme.apply)
-        .appliedToTypes(tpParams)
-        .appliedToArgs(args)
-    }
-
-    def classTag(tpe: Type) = {
-      val classTagModule = ctx.requiredModule("scala.reflect.ClassTag")
-      ref(classTagModule)
-        .select(nme.apply)
-        .appliedToType(tpe)
-        .appliedTo(clsOf(tpe))
-    }
-
-    def wrappedArray(seq: AutoSeq) = {
-      val tpe = seq.tpParam
-
-      ref(AutoCollectionModule)
-        .select(Methods.wrappedArray)
-        .appliedToType(tpe)
-        .appliedToArgs(seq.elems)
-        .appliedTo(classTag(tpe))
-    }
-
-    val methods: Set[Name] = methodCalls(collection.symbol)
-      .filterNot(_.isConstructor)
-      .map(_.name)
-
-    collection match {
-      // ------------ Immutable ------------
-
-      // if `head` and `tail` are the only operations
-      case AutoSeq(Immutable) if methods.containsOnly(head, tail) =>
-        buildCollection(collection)(ListBufferModule)
-
-      // if `:+` or `+:` are used
-      case AutoSeq(Immutable) if methods.containsSome(`+:`, `:+`) =>
-        buildCollection(collection)(ImmutableQueueModule)
-
-      // if operations are by index accesses
-      case seq @ AutoSeq(Immutable) if methods.containsSome(apply, isDefinedAt) =>
-        if (seq.tpParam =:= ctx.definitions.CharType) {
-          ref(AutoCollectionModule)
-            .select(wrappedString)
-            .appliedToArgs(seq.elems)
-        }
-        else if (!TypeErasure.isUnboundedGeneric(seq.tpParam)) wrappedArray(seq)
-        else buildCollection(seq)(VectorModule)
-
-
-      case seq @ AutoSeq(Immutable) if seq.tpParam =:= ctx.definitions.IntType =>
-        // Range if all elements are numbers with a constant delta
-        val rangeOption = {
-          val Typed(SeqLiteral(literals), _) = collection.elems.head
-
-          val MinRangeSize = 2
-
-          if (literals.size >= MinRangeSize && literals.forall(_.isInstanceOf[Literal])) {
-            val elems = literals.map {
-              case lit: Literal => lit.const.intValue
-            }
-
-            val steps = (elems.tail, elems).zipped.map(_ - _).distinct
-
-            steps match {
-              case List(step) =>
-                def lit(n: Int) = Literal(Constant(n))
-                val start = elems.head
-                val end = elems.last
-                // overload resolution
-                val inclusive = RangeModule.info.member(Methods.inclusive)
-                  .suchThat(_.info.firstParamTypes.size == 3).symbol
-                val range = ref(RangeModule)
-                  .select(inclusive)
-                  .appliedTo(lit(start), lit(end), lit(step))
-                Some(range)
-
-              case _ => None
-            }
-          } else None
-        }
-
-        rangeOption.getOrElse {
-          buildCollection(collection)(VectorModule)
-        }
-
-      // default
-      case AutoSeq(Immutable) =>
-        buildCollection(collection)(VectorModule)
-
-      // if elements are added
-      case AutoMap(Immutable) if methods.containsSome(plus, `++`) =>
-        buildCollection(collection)(ImmutableHashMapModule)
-
-      // if keys' type is subtype of `AnyReF`
-      case map @ AutoMap(Immutable) if map.keysTpe <:< ctx.definitions.AnyRefType =>
-        buildCollection(map)(AnyRefMapModule)
-
-      //  if keys' type is Long
-      case map @ AutoMap(Immutable) if map.keysTpe =:= ctx.definitions.LongType =>
-        buildCollection(map)(LongMapModule, map.valuesTpe :: Nil)
-
-      // default
-      case AutoMap(Immutable) =>
-        buildCollection(collection)(MutableHashMapModule)
-
-      // default
-      case AutoSet(Immutable) =>
-        buildCollection(collection)(ImmutableHashSetModule)
-
-
-      // ------------ Mutable ------------
-
-      // if operations are by index accesses
-      case seq @ AutoSeq(Mutable) if methods.containsSome(apply, isDefinedAt, update) =>
-        wrappedArray(seq)
-
-      // if type is known
-      case seq @ AutoSeq(Mutable) if !TypeErasure.isUnboundedGeneric(seq.tpParam) =>
-        buildCollection(seq)(UnrolledBufferModule).appliedTo(classTag(seq.tpParam))
-
-      // default
-      case AutoSeq(Mutable) =>
-        buildCollection(collection)(ListBufferModule)
-
-      case AutoMap(Mutable) =>
-        buildCollection(collection)(MutableHashMapModule)
-
-      // default
-      case AutoSet(Mutable) =>
-        buildCollection(collection)(MutableHashSetModule)
-
-
-      // ------------ Lazy ------------
-      case AutoSeq(Lazy) |  AutoMap(Lazy) | AutoSet(Lazy) =>
-        genericEmptyTree
-
     }
   }
 
@@ -268,19 +145,19 @@ object AutoCollections {
   class AutoSeq(symbol: Symbol,
                 semantic: Semantic,
                 tpParams: List[Type],
-                elems: List[Tree]) extends AutoCollection(symbol, semantic, tpParams, elems) {
+                elems: List[Tree])
+    extends AutoCollection(symbol, semantic, tpParams, elems) {
 
     require(tpParams.size == 1)
 
     def tpParam = tpParams.head
   }
 
-  object AutoSeq { def unapply(seq: AutoSeq) = Some(seq.semantic) }
-
   class AutoMap(symbol: Symbol,
                 semantic: Semantic,
                 tpParams: List[Type],
-                elems: List[Tree]) extends AutoCollection(symbol, semantic, tpParams, elems) {
+                elems: List[Tree])
+    extends AutoCollection(symbol, semantic, tpParams, elems) {
 
     require(tpParams.size == 2)
 
@@ -288,64 +165,14 @@ object AutoCollections {
     def valuesTpe = tpParams(1)
   }
 
-  object AutoMap { def unapply(map: AutoMap) = Some(map.semantic) }
-
   class AutoSet(symbol: Symbol,
                 semantic: Semantic,
                 tpParams: List[Type],
-                elems: List[Tree]) extends AutoCollection(symbol, semantic, tpParams, elems) {
+                elems: List[Tree])
+    extends AutoCollection(symbol, semantic, tpParams, elems) {
 
     require(tpParams.size == 1)
 
     def tpParam = tpParams.head
-  }
-
-  object AutoSet { def unapply(set: AutoSet) = Some(set.semantic) }
-
-  private def immutableCollectionModule(collection: String)(implicit ctx: Context) =
-    ctx.requiredModule(s"scala.collection.immutable.$collection")
-
-  private def mutableCollectionModule(collection: String)(implicit ctx: Context) =
-    ctx.requiredModule(s"scala.collection.mutable.$collection")
-
-  private def AutoCollectionModule(implicit ctx: Context) = ctx.requiredModule("scala.collection.AutoCollections")
-
-  // ------------ Seq ------------
-  private def ListBufferModule(implicit ctx: Context)     = mutableCollectionModule("ListBuffer")
-  private def UnrolledBufferModule(implicit ctx: Context) = mutableCollectionModule("UnrolledBuffer")
-  private def ImmutableQueueModule(implicit ctx: Context) = immutableCollectionModule("Queue")
-  private def VectorModule(implicit ctx: Context)         = immutableCollectionModule("Vector")
-  private def RangeModule(implicit ctx: Context)          = immutableCollectionModule("Range")
-
-  // ------------ Map ------------
-  private def MutableHashMapModule(implicit ctx: Context)   = mutableCollectionModule("HashMap")
-  private def AnyRefMapModule(implicit ctx: Context)        = mutableCollectionModule("AnyRefMap")
-  private def ImmutableHashMapModule(implicit ctx: Context) = immutableCollectionModule("HashMap")
-  private def LongMapModule(implicit ctx: Context)          = immutableCollectionModule("LongMap")
-
-  // ------------ Set ------------
-  private def MutableHashSetModule(implicit ctx: Context)   = mutableCollectionModule("HashSet")
-  private def ImmutableHashSetModule(implicit ctx: Context) = immutableCollectionModule("HashSet")
-
-
-  private object Methods {
-    val apply       = "apply".toTermName
-    val isDefinedAt = "isDefinedAt".toTermName
-    val head        = "head".toTermName
-    val tail        = "tail".toTermName
-    val `+:`        = "+:".toTermName.encode
-    val `:+`        = ":+".toTermName.encode
-    val plus        = "+".toTermName.encode
-    val `++`        = "++".toTermName.encode
-    val update      = "update".toTermName
-
-    val wrappedArray  = "wrappedArray".toTermName
-    val wrappedString = "wrappedString".toTermName
-    val inclusive     = "inclusive".toTermName
-  }
-
-  private implicit class SetOps[T](val set: Set[T]) extends AnyVal {
-    def containsSome(args: T*): Boolean = args.exists(set.contains)
-    def containsOnly(args: T*): Boolean = set == args.toSet
   }
 }

--- a/src/dotty/tools/dotc/transform/autocollections/AutoCollections.scala
+++ b/src/dotty/tools/dotc/transform/autocollections/AutoCollections.scala
@@ -1,4 +1,4 @@
-package dotty.tools.dotc.transform
+package dotty.tools.dotc.transform.autocollections
 
 import dotty.tools.dotc.ast.Trees._
 import dotty.tools.dotc.ast.tpd
@@ -11,6 +11,7 @@ import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.TypeErasure
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.transform.TreeTransforms.{MiniPhaseTransform, TransformerInfo}
+import dotty.tools.dotc.transform.BuildCallGraph
 
 import scala.collection.{immutable, mutable}
 
@@ -63,6 +64,7 @@ class AutoCollections extends MiniPhaseTransform {
   import tpd._
 
   override def phaseName: String = "autocollections"
+
 
   override def transformBlock(tree: Block)(implicit ctx: Context, info: TransformerInfo): Tree = {
     val autoCollections = ctx.preAutoCollectionPhase.asInstanceOf[PreAutoCollections].instances

--- a/src/dotty/tools/dotc/transform/autocollections/PreAutoCollections.scala
+++ b/src/dotty/tools/dotc/transform/autocollections/PreAutoCollections.scala
@@ -1,4 +1,4 @@
-package dotty.tools.dotc.transform
+package dotty.tools.dotc.transform.autocollections
 
 import dotty.tools.dotc.ast.Trees._
 import dotty.tools.dotc.ast.tpd
@@ -7,8 +7,8 @@ import dotty.tools.dotc.core.Decorators.StringDecorator
 import dotty.tools.dotc.core.StdNames._
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.MethodicType
-import dotty.tools.dotc.transform.AutoCollections._
 import dotty.tools.dotc.transform.TreeTransforms.{MiniPhaseTransform, TransformerInfo}
+import dotty.tools.dotc.transform.autocollections.AutoCollections._
 
 /** A transformation which substitutes an auto collection constructor by a
   * dummy implementation in order to track the methods called on the collection

--- a/src/dotty/tools/dotc/transform/autocollections/Rules.scala
+++ b/src/dotty/tools/dotc/transform/autocollections/Rules.scala
@@ -1,0 +1,317 @@
+package dotty.tools.dotc.transform.autocollections
+
+import dotty.tools.dotc.ast.Trees._
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Decorators.StringDecorator
+import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.StdNames._
+import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.core.TypeErasure
+import dotty.tools.dotc.core.Types.Type
+import dotty.tools.dotc.transform.autocollections.AutoCollections._
+
+object Rules {
+
+  import tpd._
+
+  /** Evaluate a list of rules and return the tree associated with the first satisfied rule */
+  def evaluate[T <: AutoCollection](rules: List[Rule[T]], collection: T, methods: Set[Name])
+                                   (implicit ctx: Context): Option[Tree] = rules match {
+    case rule :: rs =>
+      if (rule.isSatisfied(collection, methods))
+        Some(rule.tree(collection))
+      else
+        evaluate(rs, collection, methods)
+    case Nil =>
+      None
+
+  }
+
+  /**
+    * A rule define a specific collection implementation and under which
+    * conditions this implementation is optimal
+    */
+  trait Rule[T <: AutoCollection] {
+
+    /** Collection implementation associated to this rule */
+    def path: String
+
+    /** Test whether this rule is satisfied for `collection` */
+    def isSatisfied(collection: T, methods: Set[Name])(implicit ctx: Context): Boolean
+
+    /** Create an instance of the collection associated to this rule */
+    def tree(collection: T)(implicit ctx: Context): Tree = {
+      // Default to Module.apply[tpParams](elems)
+      ref(module)
+        .select(nme.apply)
+        .appliedToTypes(collection.tpParams)
+        .appliedToArgs(collection.elems)
+    }
+
+    protected def module(implicit ctx: Context): Symbol = ctx.requiredModule(path)
+  }
+
+  // ------------ Seq ------------
+
+  class ListR extends Rule[AutoSeq] {
+
+    def path: String = "scala.collection.immutable.List"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      seq.semantic == Immutable && methods.containsOnly(
+        head, tail, prepend, nonEmpty, isEmpty
+      )
+    }
+  }
+
+  class Queue extends Rule[AutoSeq] {
+
+    def path = "scala.collection.immutable.Queue"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      seq.semantic == Immutable && methods.contains(append)
+    }
+  }
+
+  class WrappedString extends Rule[AutoSeq] {
+
+    def path: String = "scala.collection.immutable.WrappedString"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      seq.semantic == Immutable &&
+      methods.containsSome(apply, isDefinedAt) &&
+      seq.tpParam =:= ctx.definitions.CharType
+    }
+
+    override def tree(seq: AutoSeq)(implicit ctx: Context): Tree = {
+      ref(AutoCollectionsModule)
+        .select("wrappedString".toTermName)
+        .appliedToArgs(seq.elems)
+    }
+  }
+
+  class WrappedArray extends Rule[AutoSeq] {
+
+    def path = "scala.collection.mutable.WrappedArray"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      (seq.semantic == Immutable || seq.semantic == Mutable) &&
+      methods.containsSome(apply, isDefinedAt, update) &&
+      isKnownType(seq.tpParam)
+    }
+
+    override def tree(seq: AutoSeq)(implicit ctx: Context): Tree = {
+      ref(AutoCollectionsModule)
+        .select("wrappedArray".toTermName)
+        .appliedToType(seq.tpParam)
+        .appliedToArgs(seq.elems)
+        .appliedTo(classTag(seq.tpParam))
+    }
+  }
+
+  class Range extends Rule[AutoSeq] {
+
+    def path = "scala.collection.immutable.Range"
+
+    final val MinRangeSize = 2
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      def isNumber(tp: Type) = tp =:= ctx.definitions.IntType
+
+      seq.semantic == Immutable && isNumber(seq.tpParam) && {
+        val Typed(SeqLiteral(literals), _) = seq.elems.head
+
+        val numbers = literals.collect {
+          case x: Literal => x.const.intValue
+        }
+
+        def allNumbers = numbers.size == literals.size
+
+        numbers.size >= MinRangeSize && allNumbers && {
+          val steps = (numbers.tail, numbers).zipped.map(_ - _).distinct
+          steps.size == 1
+        }
+      }
+    }
+
+    override def tree(seq: AutoSeq)(implicit ctx: Context): Tree = {
+      def lit(n: Int) = Literal(Constant(n))
+
+      val Typed(SeqLiteral(literals), _) = seq.elems.head
+
+      val elems = literals.map {
+        case x: Literal => x.const.intValue
+      }
+
+      val step = elems(1) - elems(0)
+      val start = elems.head
+      val end = elems.last
+
+      // overload resolution
+      val inclusive = module.info.member("inclusive".toTermName)
+        .suchThat(_.info.firstParamTypes.size == 3).symbol
+
+      ref(module)
+        .select(inclusive)
+        .appliedTo(lit(start), lit(end), lit(step))
+    }
+  }
+
+  class Vector extends Rule[AutoSeq] {
+
+    def path = "scala.collection.immutable.Vector"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean =
+      seq.semantic == Immutable
+  }
+
+  class UnrolledBuffer extends Rule[AutoSeq] {
+
+    def path = "scala.collection.mutable.UnrolledBuffer"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      seq.semantic == Mutable &&
+      isKnownType(seq.tpParam) &&
+      methods.excludes(apply, isDefinedAt, update)
+    }
+
+    override def tree(seq: AutoSeq)(implicit ctx: Context): Tree = {
+      ref(module)
+        .select(nme.apply)
+        .appliedToTypes(seq.tpParams)
+        .appliedToArgs(seq.elems)
+        .appliedTo(classTag(seq.tpParam))
+    }
+  }
+
+  class ListBuffer extends Rule[AutoSeq] {
+
+    def path = "scala.collection.mutable.ListBuffer"
+
+    def isSatisfied(seq: AutoSeq, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      seq.semantic == Mutable && methods.excludes(apply, isDefinedAt, update)
+    }
+  }
+
+  // ------------ Map ------------
+
+  class HashMap extends Rule[AutoMap] {
+
+    def path = "scala.collection.immutable.HashMap"
+
+    def isSatisfied(map: AutoMap, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      map.semantic == Immutable && methods.containsSome(plus, `++`)
+    }
+  }
+
+  class MutableAnyRefMap extends Rule[AutoMap] {
+
+    def path = "scala.collection.mutable.AnyRefMap"
+
+    def isSatisfied(map: AutoMap, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      (map.semantic == Immutable || map.semantic == Mutable) &&
+      map.keysTpe <:< ctx.definitions.AnyRefType &&
+      methods.excludes(plus, `++`)
+    }
+  }
+
+  class MutableLongMap extends Rule[AutoMap] {
+
+    def path = "scala.collection.mutable.LongMap"
+
+    def isSatisfied(map: AutoMap, methods: Set[Name])(implicit ctx: Context): Boolean = {
+      import Methods._
+
+      (map.semantic == Immutable || map.semantic == Mutable) &&
+      map.keysTpe =:= ctx.definitions.LongType &&
+      methods.excludes(plus, `++`)
+    }
+
+    override def tree(map: AutoMap)(implicit ctx: Context): Tree = {
+      ref(module)
+        .select(nme.apply)
+        .appliedToType(map.valuesTpe)
+        .appliedToArgs(map.elems)
+    }
+  }
+
+  class MutableHashMap extends Rule[AutoMap] {
+
+    def path = "scala.collection.mutable.HashMap"
+
+    def isSatisfied(map: AutoMap, methods: Set[Name])(implicit ctx: Context): Boolean =
+      map.semantic == Mutable
+  }
+
+  // ------------ Set ------------
+
+  class HashSet extends Rule[AutoSet] {
+
+    def path = "scala.collection.immutable.HashSet"
+
+    def isSatisfied(set: AutoSet, methods: Set[Name])(implicit ctx: Context): Boolean =
+      set.semantic == Immutable
+  }
+
+  class MutableHashSet extends Rule[AutoSet] {
+
+    def path = "scala.collection.mutable.HashSet"
+
+    def isSatisfied(set: AutoSet, methods: Set[Name])(implicit ctx: Context): Boolean =
+      set.semantic == Mutable
+  }
+
+  /** A class tag can be generated */
+  private def isKnownType(tpe: Type)(implicit ctx: Context) =
+    !TypeErasure.isUnboundedGeneric(tpe)
+
+  private def classTag(tpe: Type)(implicit ctx: Context) = {
+    val classTagModule = ctx.requiredModule("scala.reflect.ClassTag")
+    ref(classTagModule)
+      .select(nme.apply)
+      .appliedToType(tpe)
+      .appliedTo(clsOf(tpe))
+  }
+
+  private def AutoCollectionsModule(implicit ctx: Context) =
+    ctx.requiredModule("scala.collection.AutoCollections")
+
+  private object Methods {
+    val apply       = "apply".toTermName
+    val isDefinedAt = "isDefinedAt".toTermName
+    val head        = "head".toTermName
+    val tail        = "tail".toTermName
+    val prepend     = "+:".toTermName.encode
+    val append      = ":+".toTermName.encode
+    val plus        = "+".toTermName.encode
+    val `++`        = "++".toTermName.encode
+    val update      = "update".toTermName
+    val isEmpty     = "isEmpty".toTermName
+    val nonEmpty    = "nonEmpty".toTermName
+  }
+
+  private implicit class SetOps[T](val set: Set[T]) extends AnyVal {
+    def containsAll(args: T*):  Boolean = args.forall(set.contains)
+    def containsSome(args: T*): Boolean = args.exists(set.contains)
+    def containsOnly(args: T*): Boolean = set.subsetOf(args.toSet)
+    def excludes(args: T*):     Boolean = args.forall(!set.contains(_))
+  }
+}

--- a/src/scala/collection/AutoCollections.scala
+++ b/src/scala/collection/AutoCollections.scala
@@ -111,8 +111,8 @@ object AutoCollections {
   class ImmutableSet[T] extends Immutable.Set[T] {
     override def contains(elem: T): Boolean = ???
     override def +(elem: T): Set[T]         = ???
-    override def -(elem: T): Set[T]        = ???
-    override def iterator: Iterator[T]     = ???
+    override def -(elem: T): Set[T]         = ???
+    override def iterator: Iterator[T]      = ???
   }
 
   class MutableSet[T] extends Mutable.Set[T] {

--- a/test/dotc/AllanTests.scala
+++ b/test/dotc/AllanTests.scala
@@ -32,10 +32,10 @@ class AllanTests extends CompilerTest {
     "-Ycheck:preauto,auto"
   )
 
-  //@Test def experiment = compileFile(autoCollectionsDir, "Experiment")
+  @Test def experiment = compileFile(autoCollectionsDir, "Experiment")
   //@Test def mergeSort  = compileFile(autoCollectionsDir, "MergeSort") // Queue
   //@Test def quickSort  = compileFile(autoCollectionsDir, "QuickSort") // WrappedArray
   //@Test def bfs  = compileFile(autoCollectionsDir, "BFS") // Queue
   //@Test def dfs  = compileFile(autoCollectionsDir, "BFS") // Queue
-  @Test def pageRank = compileFile(autoCollectionsDir, "PageRank")
+  //@Test def pageRank = compileFile(autoCollectionsDir, "PageRank")
 }

--- a/test/dotc/AllanTests.scala
+++ b/test/dotc/AllanTests.scala
@@ -32,10 +32,11 @@ class AllanTests extends CompilerTest {
     "-Ycheck:preauto,auto"
   )
 
-  @Test def experiment = compileFile(autoCollectionsDir, "Experiment")
-  //@Test def mergeSort  = compileFile(autoCollectionsDir, "MergeSort") // Queue
-  //@Test def quickSort  = compileFile(autoCollectionsDir, "QuickSort") // WrappedArray
-  //@Test def bfs  = compileFile(autoCollectionsDir, "BFS") // Queue
-  //@Test def dfs  = compileFile(autoCollectionsDir, "BFS") // Queue
-  //@Test def pageRank = compileFile(autoCollectionsDir, "PageRank")
+//  @Test def experiment = compileFile(autoCollectionsDir, "Experiment")
+//  @Test def mergeSort  = compileFile(autoCollectionsDir, "MergeSort") // Queue
+//  @Test def quickSort  = compileFile(autoCollectionsDir, "QuickSort") // WrappedArray
+//  @Test def bfs  = compileFile(autoCollectionsDir, "BFS") // Queue
+//  @Test def dfs  = compileFile(autoCollectionsDir, "DFS") // List
+//  @Test def pageRank = compileFile(autoCollectionsDir, "PageRank")
+  @Test def notSupported  = compileFile(autoCollectionsDir, "NotSupported", xerrors = 3)
 }

--- a/tests/autocollections/Experiment.scala
+++ b/tests/autocollections/Experiment.scala
@@ -3,7 +3,7 @@ import scala.collection.AutoCollections._
 object Experiment {
   def main(args: Array[String]): Unit = {
     // ------------ Immutable ------------
-    val seq1 = AutoSeq("a", "b") // ListBuffer
+    val seq1 = AutoSeq("a", "b") // List
     val a = seq1.head
     val b = seq1.tail
 

--- a/tests/autocollections/NotSupported.scala
+++ b/tests/autocollections/NotSupported.scala
@@ -1,0 +1,10 @@
+import scala.collection.AutoCollections._
+
+
+object NotSupported {
+  def main(args: Array[String]): Unit = {
+    val seq = AutoSeq(1, 2)(Lazy)   // Error
+    val set = AutoSet(1, 2)(Lazy)   // Error
+    val map = AutoMap(1 -> 2)(Lazy) // Error
+  }
+}


### PR DESCRIPTION
Previously, it was a big match-cases. Now one can create a new rule by extending `Rules.Rule`
